### PR TITLE
Fixed map vessel filters throwing errors

### DIFF
--- a/Source/BetterTracking/Tracking_Controller.cs
+++ b/Source/BetterTracking/Tracking_Controller.cs
@@ -156,6 +156,7 @@ namespace BetterTracking
             GameEvents.onNewVesselCreated.Remove(new EventData<Vessel>.OnEvent(OnVesselCreate));
             GameEvents.onVesselDestroy.Remove(new EventData<Vessel>.OnEvent(OnVesselDestroy));
             GameEvents.onKnowledgeChanged.Remove(new EventData<GameEvents.HostedFromToAction<IDiscoverable, DiscoveryLevels>>.OnEvent(OnKnowledgeChange));
+            GameEvents.OnMapViewFiltersModified.Remove(new EventData<MapViewFiltering.VesselTypeFilter>.OnEvent(OnMapViewFiltersModified));
         }
 
         private IEnumerator WaitForTrackingStation()


### PR DESCRIPTION
Clicking the vessel filters in the tracking station or while flying would throw NullReferenceExceptions in the log if the tracking station has been opened at least once before. The filters still seemed to work fine though.